### PR TITLE
카드 이동 구현

### DIFF
--- a/src/css/normalize.css
+++ b/src/css/normalize.css
@@ -1,7 +1,7 @@
 * {
   margin: 0;
   padding: 0;
-  box-sizing: content-box;
+  box-sizing: border-box;
 }
 
 button {
@@ -15,6 +15,7 @@ button:disabled {
 }
 
 ul,
-ol {
+ol,
+li {
   list-style: none;
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -42,11 +42,30 @@ html {
   margin-left: 5px;
 }
 
+.column-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 10px 0;
+}
+
 .card {
+  width: 300px;
   padding: 12px 20px;
-  margin: 10px 0;
   background-color: white;
   border-radius: 10px;
+}
+
+.card.skeleton {
+  opacity: 0.4;
+  box-shadow: 0px 0px 0px 1px #0075de;
+}
+
+.card.moving {
+  z-index: 99;
+  position: absolute;
+  background: rgba(255, 255, 255, 0.8);
+  box-shadow: 0px 2px 4px 0px #00000040;
 }
 
 .card-form {

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -56,6 +56,8 @@ body {
   flex-direction: column;
   gap: 10px;
   padding: 10px 0;
+  /* 32px: 컬럼 헤더 높이 */
+  height: calc(100% - 32px);
 }
 
 .card {

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -56,16 +56,17 @@ html {
   border-radius: 10px;
 }
 
-.card.moving {
-  user-select: none;
-}
-
 .card.skeleton {
   opacity: 0.4;
   box-shadow: 0px 0px 0px 1px #0075de;
 }
 
+.card.skeleton .card-header-delete {
+  display: none;
+}
+
 .card.moving {
+  user-select: none;
   z-index: 99;
   position: absolute;
   background: rgba(255, 255, 255, 0.8);

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -2,6 +2,11 @@ html {
   background-color: rgb(225, 225, 225);
 }
 
+html,
+body {
+  height: 100%;
+}
+
 #header {
   display: flex;
   align-items: center;
@@ -13,11 +18,15 @@ html {
   display: flex;
   flex-direction: row;
   gap: 15px;
+  /* 86.5px: 헤더 높이 */
+  height: calc(100% - 86.5px);
   padding: var(--padding-outer);
 }
 
 .column {
-  width: 300px;
+  overflow: auto;
+  min-width: 300px;
+  padding: 0 6px;
 }
 
 .column-header {

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -56,6 +56,10 @@ html {
   border-radius: 10px;
 }
 
+.card.moving {
+  user-select: none;
+}
+
 .card.skeleton {
   opacity: 0.4;
   box-shadow: 0px 0px 0px 1px #0075de;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -84,8 +84,12 @@ html {
 }
 
 .card-form input[name='title'] {
-  font-size: 16px;
+  font-size: 18px;
   font-weight: 600;
+}
+
+.card-form input[name='content'] {
+  font-size: 16px;
 }
 
 .card-form-buttons {

--- a/src/js/Controller.js
+++ b/src/js/Controller.js
@@ -1,8 +1,10 @@
 import view from './view.js';
 import model from './model.js';
 
-export default class {
-  constructor() {
+class Controller {
+  constructor() {}
+
+  init() {
     this.initAllColumns();
   }
 
@@ -10,19 +12,43 @@ export default class {
     model.getAllColumns((columns) => {
       columns.forEach((column) => {
         const { id, title, todos } = column;
-        this.addColumn(id, title);
+        view.appendColumn(id, title);
         todos.forEach((todo) => {
-          this.addCard(id, todo.id, todo.title, todo.content);
+          view.appendCard(id, todo.id, todo.title, todo.content);
         });
       });
     });
   }
 
   addColumn(id, title) {
-    view.addColumn(id, title);
+    view.appendColumn(id, title);
   }
 
-  addCard(columnId, cardId, title, content) {
-    view.addCard(columnId, cardId, title, content);
+  addCard(columnId, title, content) {
+    return new Promise((resolve, reject) => {
+      // model.addCard(columnId, title, content).then((cardId) => {
+      // FIXME: id를 서버에서 반환해준 값으로 resolve
+      resolve(Date.now());
+      // });
+    });
+  }
+
+  deleteCard(cardId) {
+    return new Promise((resolve, reject) => {
+      // model.deleteCard(cardId).then(() => {
+      resolve();
+      // });
+    });
+  }
+
+  updateCard(cardId, title, content) {
+    return new Promise((resolve, reject) => {
+      // model.updateCard(cardId, title, content).then(() => {
+      resolve();
+      // });
+    });
   }
 }
+
+const controllerInstance = new Controller();
+export default controllerInstance;

--- a/src/js/Controller.js
+++ b/src/js/Controller.js
@@ -20,10 +20,6 @@ class Controller {
     });
   }
 
-  addColumn(id, title) {
-    view.appendColumn(id, title);
-  }
-
   addCard(columnId, title, content) {
     return new Promise((resolve, reject) => {
       // model.addCard(columnId, title, content).then((cardId) => {

--- a/src/js/Controller.js
+++ b/src/js/Controller.js
@@ -1,4 +1,4 @@
-import view from './view.js';
+import view from './View.js';
 import model from './model.js';
 
 class Controller {

--- a/src/js/components/Card.js
+++ b/src/js/components/Card.js
@@ -53,8 +53,7 @@ export default class {
   replaceCardWithSkeleton() {
     const $skeleton = this.$element.cloneNode(true);
     $skeleton.classList.add('skeleton');
-    this.$element.replaceWith($skeleton);
-    $skeleton.parentNode.insertBefore(this.$element, $skeleton);
+    this.$element.parentNode.insertBefore($skeleton, this.$element);
   }
 
   dragStart(event) {

--- a/src/js/components/Card.js
+++ b/src/js/components/Card.js
@@ -10,14 +10,17 @@ export default class {
       content,
     };
 
-    this.$element.classList.add('card');
-    this.$element.setAttribute('data-id', id);
-    this.render();
-    /* attach event listener */
-    this.initEvents();
+    this.init();
   }
 
-  initEvents() {
+  init() {
+    this.$element.classList.add('card');
+    this.$element.setAttribute('data-id', this.state.id);
+    this.render();
+    this.attachEvents();
+  }
+
+  attachEvents() {
     const $deleteBtn = this.$element.querySelector('.card-header-delete');
 
     $deleteBtn.addEventListener('click', this.deleteCard.bind(this));

--- a/src/js/components/Card.js
+++ b/src/js/components/Card.js
@@ -25,7 +25,10 @@ export default class {
     $deleteBtn.addEventListener('click', this.deleteCard.bind(this));
     $deleteBtn.addEventListener('mouseover', this.turnOnDanger.bind(this));
     $deleteBtn.addEventListener('mouseout', this.turnOffDanger.bind(this));
-    this.$element.addEventListener('dblclick', this.updateCard.bind(this));
+    this.$element.addEventListener(
+      'dblclick',
+      this.replaceCardWithCardForm.bind(this)
+    );
     this.$element.addEventListener('mousedown', this.dragStart.bind(this));
   }
 
@@ -33,7 +36,7 @@ export default class {
     view.removeElement(this.$element);
   }
 
-  updateCard() {
+  replaceCardWithCardForm() {
     view.replaceCardWithCardForm(
       this.$element,
       this.getTitle(),

--- a/src/js/components/Card.js
+++ b/src/js/components/Card.js
@@ -50,20 +50,50 @@ export default class {
     this.$element.style.left = `${rect.left}px`;
   }
 
-  replaceCardWithSkeleton() {
+  addSkeleton() {
     const $skeleton = this.$element.cloneNode(true);
     $skeleton.classList.add('skeleton');
     this.$element.parentNode.insertBefore($skeleton, this.$element);
+  }
+
+  getAllCardsWithoutMovingCard() {
+    return document.querySelectorAll('.card:not(.moving):not(.skeleton)');
+  }
+
+  replaceCardWithSkeleton(event) {
+    const $originalCard = event.target;
+    const $skeleton = document.querySelector('.skeleton');
+    $skeleton.classList.add('replaced');
+    event.target.replaceWith($skeleton.cloneNode(true));
+    $skeleton.replaceWith($originalCard);
+  }
+
+  setMouseEnterEventToAllCards() {
+    this.getAllCardsWithoutMovingCard().forEach((card) => {
+      card.onmouseenter = this.replaceCardWithSkeleton.bind(this);
+    });
+  }
+
+  removeMouseEnterEventToAllCards() {
+    this.getAllCardsWithoutMovingCard().forEach((card) => {
+      card.onmouseenter = null;
+    });
   }
 
   dragStart(event) {
     if (event.target.closest('.card-header-delete')) return;
 
     this.setCardInitialPosition();
-    this.replaceCardWithSkeleton();
+    this.addSkeleton();
     this.$element.classList.add('moving');
+    // 1. pointer-events를 none으로 설정한 이유: 카드 드래그 시 다른 카드의 mouseenter 이벤트를 감지하기 위해
+    // 2. setTimeout으로 delay를 넣어준 이유: dblclick 이벤트를 감지하기 위해
+    const styleTimeoutID = setTimeout(() => {
+      this.$element.style.pointerEvents = 'none';
+    }, 100);
 
     const dragStartPosition = { x: event.clientX, y: event.clientY };
+    this.setMouseEnterEventToAllCards();
     const dragEvent = (event) => {
       this.drag(event, dragStartPosition);
     };
@@ -71,6 +101,8 @@ export default class {
     window.onmouseup = (event) => {
       this.dragEnd(event);
       window.removeEventListener('mousemove', dragEvent);
+      clearTimeout(styleTimeoutID);
+      this.$element.style.pointerEvents = '';
       window.onmouseup = null;
     };
   }
@@ -83,8 +115,15 @@ export default class {
 
   dragEnd() {
     this.$element.removeAttribute('style');
-    document.querySelector('.skeleton').remove();
+    const $skeleton = document.querySelector('.skeleton');
+    // dbl 클릭 이벤트를 감지하기 위해 잔상 카드가 이동했을 때만 엘리먼트와 교체해주도록 함
+    if ($skeleton.classList.contains('replaced')) {
+      $skeleton.replaceWith(this.$element);
+    } else {
+      $skeleton.remove();
+    }
     this.$element.classList.remove('moving');
+    this.removeMouseEnterEventToAllCards();
   }
 
   getTitle() {

--- a/src/js/components/Card.js
+++ b/src/js/components/Card.js
@@ -87,7 +87,7 @@ export default class {
     const $skeleton = document.querySelector('.skeleton');
     $skeleton.classList.add('changed');
     if (event.clientY > yCenter) {
-      insertAfter($skeleton, $card);
+      view.insertAfter($skeleton, $card);
     } else {
       $card.parentNode.insertBefore($skeleton, $card);
     }
@@ -100,7 +100,7 @@ export default class {
         $skeleton.classList.add('changed');
         const newColumnId = event.target.closest('.column').dataset.id;
         this.setColumnId(newColumnId);
-        insertAfter($skeleton, $cardLists.lastChild);
+        view.insertAfter($skeleton, $cardLists.lastChild);
       };
     });
   }

--- a/src/js/components/Card.js
+++ b/src/js/components/Card.js
@@ -1,4 +1,3 @@
-import { insertAfter } from '../utils.js';
 import view from '../view.js';
 
 export default class {

--- a/src/js/components/Card.js
+++ b/src/js/components/Card.js
@@ -77,7 +77,7 @@ export default class {
 
   replaceCardWithSkeleton(event) {
     const $originalCard = event.target;
-    const $skeleton = document.querySelector('.skeleton');
+    const $skeleton = this.getSkeleton();
     view.addClass($skeleton, 'changed');
     event.target.replaceWith($skeleton.cloneNode(true));
     $skeleton.replaceWith($originalCard);
@@ -87,7 +87,7 @@ export default class {
     const $card = event.target;
     const cardRect = $card.getBoundingClientRect();
     const yCenter = cardRect.top + cardRect.height / 2;
-    const $skeleton = document.querySelector('.skeleton');
+    const $skeleton = this.getSkeleton();
     view.addClass($skeleton, 'changed');
     if (event.clientY > yCenter) {
       view.insertAfter($skeleton, $card);
@@ -99,7 +99,7 @@ export default class {
   setMouseEnterEventToAllCardLists() {
     this.getAllCardLists().forEach(($cardLists) => {
       $cardLists.onmouseenter = (event) => {
-        const $skeleton = document.querySelector('.skeleton');
+        const $skeleton = this.getSkeleton();
         view.addClass($skeleton, 'changed');
         const newColumnId = event.target.closest('.column').dataset.id;
         this.setColumnId(newColumnId);
@@ -175,7 +175,7 @@ export default class {
 
   dragEnd() {
     this.$element.removeAttribute('style');
-    const $skeleton = document.querySelector('.skeleton');
+    const $skeleton = this.getSkeleton();
     // dblclick 이벤트를 감지하기 위해 잔상 카드가 이동했을 때만 엘리먼트와 교체해주도록 함
     if ($skeleton.classList.contains('changed')) {
       $skeleton.replaceWith(this.$element);
@@ -197,6 +197,10 @@ export default class {
 
   getElement() {
     return this.$element;
+  }
+
+  getSkeleton() {
+    return document.querySelector('.skeleton');
   }
 
   render() {

--- a/src/js/components/Card.js
+++ b/src/js/components/Card.js
@@ -57,6 +57,10 @@ export default class {
     this.$element.parentNode.insertBefore($skeleton, this.$element);
   }
 
+  getAllCardLists() {
+    return document.querySelectorAll('.column-cards');
+  }
+
   getAllCardsWithoutMovingCard() {
     return document.querySelectorAll('.card:not(.moving):not(.skeleton)');
   }
@@ -82,6 +86,18 @@ export default class {
     }
   }
 
+  setMouseEnterEventToAllCardLists() {
+    this.getAllCardLists().forEach(($cardLists) => {
+      $cardLists.onmouseenter = (event) => {
+        const $skeleton = document.querySelector('.skeleton');
+        $skeleton.classList.add('changed');
+        const newColumnId = event.target.closest('.column').dataset.id;
+        this.setColumnId(newColumnId);
+        insertAfter($skeleton, $cardLists.lastChild);
+      };
+    });
+  }
+
   setMouseEnterEventToAllCards() {
     this.getAllCardsWithoutMovingCard().forEach(($card) => {
       $card.onmouseenter = (event) => {
@@ -93,6 +109,12 @@ export default class {
         }
         this.setColumnId(newColumnId);
       };
+    });
+  }
+
+  removeMouseEnterEventToAllCardLists() {
+    this.getAllCardLists().forEach((cardList) => {
+      cardList.onmouseenter = null;
     });
   }
 
@@ -120,6 +142,7 @@ export default class {
     }, 100);
 
     const dragStartPosition = { x: event.clientX, y: event.clientY };
+    this.setMouseEnterEventToAllCardLists();
     this.setMouseEnterEventToAllCards();
     const dragEvent = (event) => {
       this.drag(event, dragStartPosition);
@@ -150,6 +173,7 @@ export default class {
       $skeleton.remove();
     }
     this.$element.classList.remove('moving');
+    this.removeMouseEnterEventToAllCardLists();
     this.removeMouseEnterEventToAllCards();
   }
 

--- a/src/js/components/Card.js
+++ b/src/js/components/Card.js
@@ -23,6 +23,7 @@ export default class {
     $deleteBtn.addEventListener('mouseover', this.turnOnDanger.bind(this));
     $deleteBtn.addEventListener('mouseout', this.turnOffDanger.bind(this));
     this.$element.addEventListener('dblclick', this.updateCard.bind(this));
+    this.$element.addEventListener('mousedown', this.dragStart.bind(this));
   }
 
   deleteCard() {
@@ -41,6 +42,50 @@ export default class {
   turnOffDanger() {
     const $card = this.$element;
     view.turnOffCardDanger($card);
+  }
+
+  setCardInitialPosition() {
+    const rect = this.$element.getBoundingClientRect();
+    this.$element.style.top = `${rect.top}px`;
+    this.$element.style.left = `${rect.left}px`;
+  }
+
+  replaceCardWithSkeleton() {
+    const $skeleton = this.$element.cloneNode(true);
+    $skeleton.classList.add('skeleton');
+    this.$element.replaceWith($skeleton);
+    $skeleton.parentNode.insertBefore(this.$element, $skeleton);
+  }
+
+  dragStart(event) {
+    if (event.target.closest('.card-header-delete')) return;
+
+    this.setCardInitialPosition();
+    this.replaceCardWithSkeleton();
+    this.$element.classList.add('moving');
+
+    const dragStartPosition = { x: event.clientX, y: event.clientY };
+    const dragEvent = (event) => {
+      this.drag(event, dragStartPosition);
+    };
+    window.addEventListener('mousemove', dragEvent);
+    window.onmouseup = (event) => {
+      this.dragEnd(event);
+      window.removeEventListener('mousemove', dragEvent);
+      window.onmouseup = null;
+    };
+  }
+
+  drag(event, dragStartPosition) {
+    const xDiff = event.clientX - dragStartPosition.x;
+    const yDiff = event.clientY - dragStartPosition.y;
+    this.$element.style.transform = `translate(${xDiff}px, ${yDiff}px)`;
+  }
+
+  dragEnd() {
+    this.$element.removeAttribute('style');
+    document.querySelector('.skeleton').remove();
+    this.$element.classList.remove('moving');
   }
 
   getTitle() {

--- a/src/js/components/Card.js
+++ b/src/js/components/Card.js
@@ -139,7 +139,7 @@ export default class {
     // 2. setTimeout으로 delay를 넣어준 이유: dblclick 이벤트를 감지하기 위해
     const styleTimeoutID = setTimeout(() => {
       this.$element.style.pointerEvents = 'none';
-    }, 100);
+    }, 150);
 
     const dragStartPosition = { x: event.clientX, y: event.clientY };
     this.setMouseEnterEventToAllCardLists();

--- a/src/js/components/Card.js
+++ b/src/js/components/Card.js
@@ -143,7 +143,7 @@ export default class {
 
     this.setCardInitialPosition();
     this.addSkeleton();
-    view.addClass($element, ' moving');
+    view.addClass(this.$element, 'moving');
     this.setColumnId(this.$element.closest('.column').dataset.id);
     // 1. pointer-events를 none으로 설정한 이유: 카드 드래그 시 다른 카드의 mouseenter 이벤트를 감지하기 위해
     // 2. setTimeout으로 delay를 넣어준 이유: dblclick 이벤트를 감지하기 위해

--- a/src/js/components/Card.js
+++ b/src/js/components/Card.js
@@ -35,7 +35,11 @@ export default class {
   }
 
   updateCard() {
-    view.updateCard(this.$element, this.getTitle(), this.getContent());
+    view.replaceCardWithCardForm(
+      this.$element,
+      this.getTitle(),
+      this.getContent()
+    );
   }
 
   turnOnDanger() {

--- a/src/js/components/Card.js
+++ b/src/js/components/Card.js
@@ -1,4 +1,5 @@
-import view from '../view.js';
+import view from '../View.js';
+import controller from '../Controller.js';
 
 export default class {
   constructor(id, title, content) {
@@ -13,7 +14,7 @@ export default class {
   }
 
   init() {
-    this.$element.classList.add('card');
+    this.$element.className = 'card';
     this.$element.setAttribute('data-id', this.state.id);
     this.render();
     this.attachEvents();
@@ -33,7 +34,9 @@ export default class {
   }
 
   deleteCard() {
-    view.removeElement(this.$element);
+    controller.deleteCard(this.$element.dataset.id).then(() => {
+      view.removeElement(this.$element);
+    });
   }
 
   replaceCardWithCardForm() {
@@ -45,13 +48,11 @@ export default class {
   }
 
   turnOnDanger() {
-    const $card = this.$element;
-    view.turnOnCardDanger($card);
+    view.addClass(this.$element, 'danger');
   }
 
   turnOffDanger() {
-    const $card = this.$element;
-    view.turnOffCardDanger($card);
+    view.removeClass(this.$element, 'danger');
   }
 
   setCardInitialPosition() {
@@ -62,7 +63,7 @@ export default class {
 
   addSkeleton() {
     const $skeleton = this.$element.cloneNode(true);
-    $skeleton.classList.add('skeleton');
+    view.addClass($skeleton, 'skeleton');
     this.$element.parentNode.insertBefore($skeleton, this.$element);
   }
 
@@ -77,7 +78,7 @@ export default class {
   replaceCardWithSkeleton(event) {
     const $originalCard = event.target;
     const $skeleton = document.querySelector('.skeleton');
-    $skeleton.classList.add('changed');
+    view.addClass($skeleton, 'changed');
     event.target.replaceWith($skeleton.cloneNode(true));
     $skeleton.replaceWith($originalCard);
   }
@@ -87,7 +88,7 @@ export default class {
     const cardRect = $card.getBoundingClientRect();
     const yCenter = cardRect.top + cardRect.height / 2;
     const $skeleton = document.querySelector('.skeleton');
-    $skeleton.classList.add('changed');
+    view.addClass($skeleton, 'changed');
     if (event.clientY > yCenter) {
       view.insertAfter($skeleton, $card);
     } else {
@@ -99,7 +100,7 @@ export default class {
     this.getAllCardLists().forEach(($cardLists) => {
       $cardLists.onmouseenter = (event) => {
         const $skeleton = document.querySelector('.skeleton');
-        $skeleton.classList.add('changed');
+        view.addClass($skeleton, 'changed');
         const newColumnId = event.target.closest('.column').dataset.id;
         this.setColumnId(newColumnId);
         view.insertAfter($skeleton, $cardLists.lastChild);
@@ -142,7 +143,7 @@ export default class {
 
     this.setCardInitialPosition();
     this.addSkeleton();
-    this.$element.classList.add('moving');
+    view.addClass($element, ' moving');
     this.setColumnId(this.$element.closest('.column').dataset.id);
     // 1. pointer-events를 none으로 설정한 이유: 카드 드래그 시 다른 카드의 mouseenter 이벤트를 감지하기 위해
     // 2. setTimeout으로 delay를 넣어준 이유: dblclick 이벤트를 감지하기 위해
@@ -181,7 +182,7 @@ export default class {
     } else {
       $skeleton.remove();
     }
-    this.$element.classList.remove('moving');
+    view.removeClass(this.$element, 'moving');
     this.removeMouseEnterEventToAllCardLists();
     this.removeMouseEnterEventToAllCards();
   }

--- a/src/js/components/CardForm.js
+++ b/src/js/components/CardForm.js
@@ -8,13 +8,16 @@ export default class {
       content,
     };
 
-    this.$element.classList.add('card');
-    this.render();
-    /* attach event listener */
-    this.initEvents();
+    this.init();
   }
 
-  initEvents() {
+  init() {
+    this.$element.classList.add('card');
+    this.render();
+    this.attachEvents();
+  }
+
+  attachEvents() {
     this.$element
       .querySelector('.card-form-cancelbtn')
       .addEventListener('click', this.cancelSubmit.bind(this));

--- a/src/js/components/CardForm.js
+++ b/src/js/components/CardForm.js
@@ -1,4 +1,4 @@
-import view from '../view.js';
+import view from '../View.js';
 
 export default class {
   constructor(action, id = '', title = '', content = '') {
@@ -14,7 +14,7 @@ export default class {
   }
 
   init() {
-    this.$element.classList.add('card');
+    this.$element.className = 'card';
     this.$element.dataset.id = this.state.id;
     this.$element.dataset.action = this.state.action;
     this.render();

--- a/src/js/components/CardForm.js
+++ b/src/js/components/CardForm.js
@@ -1,9 +1,11 @@
 import view from '../view.js';
 
 export default class {
-  constructor(title = '', content = '') {
+  constructor(action, id = '', title = '', content = '') {
     this.$element = document.createElement('li');
     this.state = {
+      action,
+      id,
       title,
       content,
     };
@@ -13,6 +15,8 @@ export default class {
 
   init() {
     this.$element.classList.add('card');
+    this.$element.dataset.id = this.state.id;
+    this.$element.dataset.action = this.state.action;
     this.render();
     this.attachEvents();
   }

--- a/src/js/components/CardForm.js
+++ b/src/js/components/CardForm.js
@@ -65,12 +65,12 @@ export default class {
 
   activateSubmit() {
     const $submitBtn = this.$element.querySelector('.card-form-submitbtn');
-    view.activateBtn($submitBtn);
+    $submitBtn.removeAttribute('disabled');
   }
 
   deactivateSubmit() {
     const $submitBtn = this.$element.querySelector('.card-form-submitbtn');
-    view.deactivateBtn($submitBtn);
+    $submitBtn.setAttribute('disabled', true);
   }
 
   getTitle() {

--- a/src/js/components/Column.js
+++ b/src/js/components/Column.js
@@ -1,4 +1,4 @@
-import view from '../view.js';
+import view from '../View.js';
 
 export default class {
   constructor(id, title) {
@@ -12,7 +12,7 @@ export default class {
   }
 
   init() {
-    this.$element.classList.add('column');
+    this.$element.className = 'column';
     this.$element.setAttribute('data-id', this.state.id);
     this.render();
     this.attachEvents();
@@ -36,10 +36,9 @@ export default class {
   }
 
   removeCardForm() {
-    const $column = this.$element.closest('.column');
-    const $cardList = $column.querySelector('.column-cards');
-
-    view.removeCardForm($column, $cardList);
+    const $cardList = this.$element.querySelector('.column-cards');
+    view.removeClass(this.$element, 'adding');
+    view.removeElement($cardList.firstChild);
   }
 
   getElement() {

--- a/src/js/components/Column.js
+++ b/src/js/components/Column.js
@@ -8,13 +8,17 @@ export default class {
       id,
     };
 
+    this.init();
+  }
+
+  init() {
     this.$element.classList.add('column');
     this.$element.setAttribute('data-id', this.state.id);
     this.render();
-    this.initEvents();
+    this.attachEvents();
   }
 
-  initEvents() {
+  attachEvents() {
     this.$element
       .querySelector('.column-header-add')
       .addEventListener('click', () => {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,6 +1,6 @@
 import '../css/normalize.css';
 import '../css/variables.css';
 import '../css/style.css';
-import Controller from './Controller.js';
+import controller from './Controller.js';
 
-new Controller();
+controller.init();

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,0 +1,3 @@
+export function insertAfter(newNode, existingNode) {
+  existingNode.parentNode.insertBefore(newNode, existingNode.nextSibling);
+}

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,3 +1,0 @@
-export function insertAfter(newNode, existingNode) {
-  existingNode.parentNode.insertBefore(newNode, existingNode.nextSibling);
-}

--- a/src/js/view.js
+++ b/src/js/view.js
@@ -54,28 +54,30 @@ class View {
     $cardForm.replaceWith($card.getElement());
   }
 
+  addCard($column, $cardForm, title, content) {
+    controller.addCard($column.dataset.id, title, content).then((cardId) => {
+      this.replaceCardFormWithCard(cardId, $column, $cardForm, title, content);
+    });
+  }
+
+  updateCard($column, $cardForm, title, content) {
+    controller.updateCard($column.dataset.id, title, content).then(() => {
+      this.replaceCardFormWithCard(
+        $cardForm.dataset.id,
+        $column,
+        $cardForm,
+        title,
+        content
+      );
+    });
+  }
+
   confirmCardFormSubmit($column, $cardForm, title, content) {
     const { action } = $cardForm.dataset;
     if (action === 'add') {
-      controller.addCard($column.dataset.id, title, content).then((cardId) => {
-        this.replaceCardFormWithCard(
-          cardId,
-          $column,
-          $cardForm,
-          title,
-          content
-        );
-      });
+      this.addCard($column, $cardForm, title, content);
     } else if (action === 'update') {
-      controller.updateCard($column.dataset.id, title, content).then(() => {
-        this.replaceCardFormWithCard(
-          $cardForm.dataset.id,
-          $column,
-          $cardForm,
-          title,
-          content
-        );
-      });
+      this.updateCard($column, $cardForm, title, content);
     }
   }
 

--- a/src/js/view.js
+++ b/src/js/view.js
@@ -92,14 +92,6 @@ class View {
 
   cancelUpdateCard($column, $cardForm) {}
 
-  activateBtn($button) {
-    $button.removeAttribute('disabled');
-  }
-
-  deactivateBtn($button) {
-    $button.setAttribute('disabled', true);
-  }
-
   replaceCardWithCardForm($card, title, content) {
     $card.replaceWith(
       new CardForm('update', $card.dataset.id, title, content).getElement()

--- a/src/js/view.js
+++ b/src/js/view.js
@@ -6,12 +6,20 @@ import controller from './Controller.js';
 class View {
   constructor() {}
 
+  removeElement($element) {
+    $element.remove();
+  }
+
   insertAfter($newNode, $existingNode) {
     $existingNode.parentNode.insertBefore($newNode, $existingNode.nextSibling);
   }
 
-  removeElement($element) {
-    $element.remove();
+  addClass($element, className) {
+    $element.classList.add(className);
+  }
+
+  removeClass($element, className) {
+    $element.classList.remove(className);
   }
 
   appendColumn(id, title) {
@@ -32,27 +40,16 @@ class View {
     });
   }
 
-  deleteCard($card) {
-    controller.deleteCard($card.dataset.id).then(() => {
-      this.removeElement($card);
-    });
-  }
-
   addCardForm($column, $cardList) {
-    $column.classList.add('adding');
+    this.addClass($column, 'adding');
     $cardList.insertBefore(
       new CardForm('add').getElement(),
       $cardList.firstChild
     );
   }
 
-  removeCardForm($column, $cardList) {
-    $column.classList.remove('adding');
-    this.removeElement($cardList.firstChild);
-  }
-
   replaceCardFormWithCard(cardId, $column, $cardForm, title, content) {
-    $column.classList.remove('adding');
+    this.removeClass($column, 'adding');
     const $card = new Card(cardId, title, content);
     $cardForm.replaceWith($card.getElement());
   }
@@ -84,7 +81,7 @@ class View {
 
   cancelCardFormSubmit($column, $cardForm) {
     if ($column.classList.contains('adding')) {
-      $column.classList.remove('adding');
+      this.removeClass($column, 'adding');
       this.removeElement($cardForm);
     } else {
       this.cancelUpdateCard($column, $cardForm);
@@ -105,14 +102,6 @@ class View {
     $card.replaceWith(
       new CardForm('update', $card.dataset.id, title, content).getElement()
     );
-  }
-
-  turnOnCardDanger($card) {
-    $card.classList.add('danger');
-  }
-
-  turnOffCardDanger($card) {
-    $card.classList.remove('danger');
   }
 }
 

--- a/src/js/view.js
+++ b/src/js/view.js
@@ -6,6 +6,10 @@ import controller from './Controller.js';
 class View {
   constructor() {}
 
+  insertAfter($newNode, $existingNode) {
+    $existingNode.parentNode.insertBefore($newNode, $existingNode.nextSibling);
+  }
+
   removeElement($element) {
     $element.remove();
   }


### PR DESCRIPTION
# 개요 

카드 위 아래 이동 및 컬럼 간 이동을 구현했습니다. 애니메이션은 구현하지 못했어요.

# 애니메이션 최적화

카드 드래그 시 transform 스타일을 이용해서 이동시켜주도록 했습니다. top, left로 위치를 변경하게 되면 매번 top, left가 변할 때마다 모든 프레임과 엘리먼트의 배경이 합성되는 데 비해, transform을 이용하면 레이어가 분리되기 때문에 다른 프레임과 합성되지 않아 성능적으로 이점이 있습니다.

참고 자료: https://ui.toast.com/fe-guide/ko_PERFORMANCE#transform%EC%82%AC%EC%9A%A9

# CSS로 엘리먼트 높이 100%로 만들기

높이나 너비를 %로 지정하게 되면 부모 높이나 너비의 상대 값으로 설정되게 되므로, html, body의 높이를 100%로 설정해줘야 하위 엘리먼트의 높이를 100%로 설정했을 때, 전체 높이로 설정할 수 있게 됩니다. 컬럼 높이를 main 태그의 최대 높이로 설정하기 위해 height 100%에서 헤더 높이를 빼준 값으로 설정했습니다.

참고 자료: https://offbyone.tistory.com/341

# 관련 이슈

#3 