### PR TITLE
컬럼 간 카드 이동 시 순서 이상해지는 버그 해결 + 컬럼 카드 개수 카운트

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -46,7 +46,7 @@ body {
   width: 25px;
   padding: 4px;
   border-radius: 40%;
-  margin-left: 5px;
+  margin-left: 8px;
 }
 
 .column-cards {

--- a/src/js/Controller.js
+++ b/src/js/Controller.js
@@ -11,11 +11,12 @@ class Controller {
   initAllColumns() {
     model.getAllColumns().then((columns) => {
       columns.forEach((column) => {
-        const { id, title, todos } = column;
-        view.appendColumn(id, title);
+        const { id: columnId, title, todos } = column;
+        view.appendColumn(columnId, title);
         todos.forEach((todo) => {
-          view.appendCard(id, todo.id, todo.title, todo.content);
+          view.appendCard(columnId, todo.id, todo.title, todo.content);
         });
+        view.setColumnCardsCount(columnId, todos.length);
       });
     });
   }

--- a/src/js/components/Card.js
+++ b/src/js/components/Card.js
@@ -81,8 +81,17 @@ export default class {
     const $originalCard = event.target;
     const $skeleton = this.getSkeleton();
     view.addClass($skeleton, 'changed');
-    event.target.replaceWith($skeleton.cloneNode(true));
-    $skeleton.replaceWith($originalCard);
+
+    const $cards = [...this.getCardsWithoutMoving($skeleton)];
+    const skeletonIndex = $cards.indexOf($skeleton);
+    const cardIndex = $cards.indexOf($originalCard);
+
+    const isSkeletonAboveCard = skeletonIndex < cardIndex;
+    if (isSkeletonAboveCard) {
+      view.insertAfter($skeleton, $originalCard);
+    } else {
+      $originalCard.parentNode.insertBefore($skeleton, $originalCard);
+    }
   }
 
   moveSkeletonToAdjacentCard(event) {
@@ -212,10 +221,14 @@ export default class {
     return document.querySelector('.skeleton');
   }
 
+  getCardsWithoutMoving($skeleton) {
+    const $cardList = $skeleton.closest('.column-cards');
+    return $cardList.querySelectorAll('.card:not(.moving)');
+  }
+
   getDestinationPosition() {
     const $skeleton = this.getSkeleton();
-    const $cardList = $skeleton.closest('.column-cards');
-    const $cards = $cardList.querySelectorAll('.card:not(.moving)');
+    const $cards = this.getCardsWithoutMoving($skeleton);
     const skeletonIndex = [...$cards].indexOf($skeleton);
 
     return $cards.length - skeletonIndex;

--- a/src/js/components/Card.js
+++ b/src/js/components/Card.js
@@ -36,6 +36,8 @@ export default class {
   deleteCard() {
     if (window.confirm('선택한 카드를 삭제할까요?')) {
       controller.deleteCard(this.$element.dataset.id).then(() => {
+        const columnId = this.$element.closest('.column').dataset.id;
+        view.removeColumnCardsCount(columnId);
         view.removeElement(this.$element);
       });
     }
@@ -189,14 +191,21 @@ export default class {
     const $skeleton = this.getSkeleton();
     // dblclick 이벤트를 감지하기 위해 잔상 카드가 이동했을 때만 엘리먼트와 교체해주도록 함
     if ($skeleton.classList.contains('changed')) {
+      const $originalColumn = this.$element.closest('.column');
+      const $newColumn = $skeleton.closest('.column');
+      const originalColumnId = $originalColumn.dataset.id;
+      const newColumnId = $newColumn.dataset.id;
+
       controller
-        .moveCard(
-          this.state.id,
-          this.getDestinationPosition(),
-          $skeleton.closest('.column').dataset.id
-        )
-        .then($skeleton.replaceWith(this.$element))
-        .catch($skeleton.remove());
+        .moveCard(this.state.id, this.getDestinationPosition(), newColumnId)
+        .then(() => {
+          view.removeColumnCardsCount(originalColumnId);
+          view.addColumnCardsCount(newColumnId);
+          $skeleton.replaceWith(this.$element);
+        })
+        .catch(() => {
+          $skeleton.remove();
+        });
     } else {
       $skeleton.remove();
     }

--- a/src/js/components/Column.js
+++ b/src/js/components/Column.js
@@ -48,8 +48,10 @@ export default class {
   render() {
     this.$element.innerHTML = `
         <div class="column-header">
-            <h2 class="column-header-title">${this.state.title}</h2>
-            <div class="column-header-counter">0</div>
+            <div>
+                <h2 class="column-header-title">${this.state.title}</h2>
+                <div class="column-header-counter">0</div>
+            </div>
             <div> 
                 <button class="column-header-add">
                     <svg width="24" height="24" viewBox="0 0 24 24" fill="none"

--- a/src/js/view.js
+++ b/src/js/view.js
@@ -40,6 +40,26 @@ class View {
     });
   }
 
+  getColumnCardsCounter(columnId) {
+    const selector = `.column[data-id="${columnId}"] .column-header-counter`;
+    return document.querySelector(selector);
+  }
+
+  setColumnCardsCount(columnId, count) {
+    const $counter = this.getColumnCardsCounter(columnId);
+    $counter.innerHTML = count;
+  }
+
+  addColumnCardsCount(columnId) {
+    const $counter = this.getColumnCardsCounter(columnId);
+    $counter.innerHTML++;
+  }
+
+  removeColumnCardsCount(columnId) {
+    const $counter = this.getColumnCardsCounter(columnId);
+    $counter.innerHTML--;
+  }
+
   addCardForm($column, $cardList) {
     this.addClass($column, 'adding');
     $cardList.insertBefore(
@@ -55,8 +75,10 @@ class View {
   }
 
   addCard($column, $cardForm, title, content) {
-    controller.addCard($column.dataset.id, title, content).then((cardId) => {
+    const columnId = $column.dataset.id;
+    controller.addCard(columnId, title, content).then((cardId) => {
       this.replaceCardFormWithCard(cardId, $column, $cardForm, title, content);
+      this.addColumnCardsCount(columnId);
     });
   }
 


### PR DESCRIPTION
# 작업 내용

컬럼 간 카드 이동 시 순서가 이상해지는 버그는 다음과 같은 이유로 발생했습니다.

1. 컬럼의 mouseenter 이벤트가 잔상 카드를 맨 아래로 보낸다.
2. 동시에 카드의 mouseenter 이벤트가 잔상 카드를 replace한다.
3. 따라서 컬럼 이동과 동시에 카드와 잔상 카드가 replace되면서 순서가 이상해진다.

카드 개수 카운트 기능도 구현했습니다.

# 관련 이슈

#1